### PR TITLE
Fix global options (gon.options) access

### DIFF
--- a/lib/pulse_meter/visualize/coffee/presenters/widget.coffee
+++ b/lib/pulse_meter/visualize/coffee/presenters/widget.coffee
@@ -30,7 +30,7 @@ class WidgetPresenter
 
 		$.extend(true,
 			@options(),
-			@globalOptions.gchartOptions,
+			@globalOptions().gchartOptions,
 			pageOptions,
 			@get('gchartOptions')
 		)

--- a/lib/pulse_meter/visualize/public/js/application.js
+++ b/lib/pulse_meter/visualize/public/js/application.js
@@ -262,7 +262,7 @@ WidgetPresenter = (function() {
   WidgetPresenter.prototype.mergedOptions = function() {
     var pageOptions;
     pageOptions = this.pageInfos.selected() ? this.pageInfos.selected().get('gchartOptions') : {};
-    return $.extend(true, this.options(), this.globalOptions.gchartOptions, pageOptions, this.get('gchartOptions'));
+    return $.extend(true, this.options(), this.globalOptions().gchartOptions, pageOptions, this.get('gchartOptions'));
   };
 
   WidgetPresenter.prototype.data = function() {


### PR DESCRIPTION
I wanted to decrease graphs height (to fit them to screen):

``` diff
diff --git a/pulse.ru b/pulse.ru
index 84d2048..a8f6c4c 100644
--- a/pulse.ru
+++ b/pulse.ru
@@ -5,6 +5,7 @@ PulseMeter.redis = Redis.new

 pulse = PulseMeter::Visualizer.draw do |l|
   l.embedded true
+  l.gchart_options height: 250

   l.page "All" do |p|
     p.line "Sidekiq queues" do |w|
```

No effect!

I debugged.
