### PR TITLE
'Not enough columns given to draw the requested chart.' error fix for timeline widgets

### DIFF
--- a/lib/pulse_meter/visualize/coffee/presenters/timeline.coffee
+++ b/lib/pulse_meter/visualize/coffee/presenters/timeline.coffee
@@ -4,10 +4,14 @@ class TimelinePresenter extends WidgetPresenter
 		data.addColumn('datetime', 'Time')
 		dateOffset = @dateOffset() + @get('interval') * 1000
 		series = @get('series')
-		_.each series.titles, (t) ->
-			data.addColumn('number', t)
+		if _.size(series.titles) > 0
+			_.each series.titles, (t) ->
+				data.addColumn('number', t)
 
-		_.each series.rows, (row) ->
-			row[0] = new Date(row[0] + dateOffset)
-			data.addRow(row)
+			_.each series.rows, (row) ->
+				row[0] = new Date(row[0] + dateOffset)
+				data.addRow(row)
+		else
+			# dummy column to render an empty chart but not a error
+			data.addColumn('number')
 		data

--- a/lib/pulse_meter/visualize/public/js/application.js
+++ b/lib/pulse_meter/visualize/public/js/application.js
@@ -363,13 +363,17 @@ TimelinePresenter = (function(_super) {
     data.addColumn('datetime', 'Time');
     dateOffset = this.dateOffset() + this.get('interval') * 1000;
     series = this.get('series');
-    _.each(series.titles, function(t) {
-      return data.addColumn('number', t);
-    });
-    _.each(series.rows, function(row) {
-      row[0] = new Date(row[0] + dateOffset);
-      return data.addRow(row);
-    });
+    if (_.size(series.titles) > 0) {
+      _.each(series.titles, function(t) {
+        return data.addColumn('number', t);
+      });
+      _.each(series.rows, function(row) {
+        row[0] = new Date(row[0] + dateOffset);
+        return data.addRow(row);
+      });
+    } else {
+      data.addColumn('number');
+    }
     return data;
   };
 


### PR DESCRIPTION
Problem: If there is no valid sensor for an area widget, google chart renders only the error 'Not enough columns given to draw the requested chart.', but not the title or some other useful info. It seems annoying, because users can't identify charts.

The pr fixes it by adding a dummy column when it's necessary, so an empty graph is rendered when there is no valid sensor. Cavet: a legend with one element without any title is rendered too (it's a dummy column's legend item).
